### PR TITLE
Larger settings dialog for "google-message" theme.

### DIFF
--- a/themes/google-messages/style.css
+++ b/themes/google-messages/style.css
@@ -118,14 +118,14 @@ body {
 /* Google Messages General Modal */
 .google-message-general-modal-content {
 	background-color: #131313;
-	margin: 10% auto;
-	width: 60%; /* Adjust modal width as needed */
+	margin: 5% auto;
+	width: 95%; /* Adjust modal width as needed */
+	max-height: 90%;
 	border-radius: 10px; /* Rounded corners */
 	box-shadow: 0 4px 8px 0 var(--border_color);
 	color: var(--main_text_color);
 	position: relative; /* To position close button */
 	padding: 10px;
-	max-height: 60vh;
 }
 
 .google-message-st-modal-title-div {
@@ -175,7 +175,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	padding: 0px 0px 0px 8px;
-	width: 70px;
+	width: 60px;
 }
 
 .google-message-st-options::selection {
@@ -188,7 +188,7 @@ body {
 	flex-direction: column;
 	overflow-y: auto;
 	width: 100%;
-	max-height: 53vh;
+	max-height: 70vh;
 }
 
 .google-message-st-option-preview {

--- a/themes/google-messages/style.css
+++ b/themes/google-messages/style.css
@@ -196,7 +196,7 @@ body {
 }
 
 /* Modify the modal content for mobile */
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 400px) {
 	.google-message-modal {
 		left: 15px;
 	}
@@ -233,7 +233,7 @@ body {
 	}
 }
 
-@media screen and (min-width: 769px) and (max-width: 1000px) {
+@media screen and (min-width: 401px) and (max-width: 1000px) {
 	.google-message-modal-content {
 		width: 385px;
 	}

--- a/themes/google-messages/style.css
+++ b/themes/google-messages/style.css
@@ -201,7 +201,7 @@ body {
 		left: 15px;
 	}
 	.google-message-modal-content {
-		width: 335px;
+		width: 345px;
 	}
 	.google-message-st-modal-close {
 		font-size: 32px;
@@ -233,12 +233,12 @@ body {
 	}
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (min-width: 769px) and (max-width: 1000px) {
 	.google-message-modal-content {
 		width: 385px;
 	}
 	.google-message-general-modal-content {
-		min-width: 47vh;
+		min-width: 43vh;
 		max-height: unset;
 	}
 }


### PR DESCRIPTION
This PR increases the width and height of the settings dialog for the "google-message" theme. The previous/current dialog is too small IMHO to edit all the different settings easily.

- Tested on Firefox 134.0, resolution 1920x1080
- Responsiveness seems to work fine, tested by resizing the browser window to different sizes.
- Disclaimer: I don't know much about CSS, so please **review**.

Thank you for this awesome extension, it makes the UI of ST much better.

