### PR TITLE
refactor: guinevere ui code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Guinevere UI Extension is a massive extension for SillyTavern that basically
 
 ## Features
 
-1. A complete overhaul of SillyTavern's original UI in one added line of code.
+1. A complete overhaul of SillyTavern's original UI with one click of a button.
     > To put it briefly, SillyTavern's UI hasn't really aged well for some folk, especially those who either come from a AI website like C.AI or were using TavernAI, MikuPad, etc. (Trust me. I was on the same boat for a while). Well rest easy now that you have full control of the UI with whatever placement, icons, images you wish to add whether it be mimicking a existing UI or making one from scratch!
 
     <p align="center">
@@ -76,7 +76,7 @@ See the `template` folder in your Guinevere's theme folder as a starter to make 
 
 1. If you plan to share your theme, make sure your theme works for mobile users! Or at least state this is mostly a Desktop designed theme. People may install your theme and wonder why it looks jank on their end. Use different monitors, devices, etc.
 2. Preferably use CSS that exists in ST already! People may want to apply a UI theme over yours! Be grateful people will use your theme and allow others to style it more their way too!
-3. Do not change any of Guinevere's code lines unless you *know* what you are doing. To put it frank, the internals are only needed to work the execution of stuff on the frontend side. All your code should go into your themes folder. JS code should be executed using a `code.js` file.
+3. Do not change any of Guinevere's code lines unless you *know* what you're doing. To put it frank, the internals are only needed to work the execution of stuff on the frontend side. All your code should go into your themes folder. JS code should be executed using a `code.js` file.
 4. Make sure you test your theme rigurously. Especially when it comes to resetting. People are gonna wonder why your theme breaks other themes if you don't reset it properly and not recommend it.
 5. Don't be a dolt. Just do this for fun and not of malice.
 

--- a/index.js
+++ b/index.js
@@ -134,10 +134,8 @@ async function applyTheme(silent) {
 				await applyCssTheme(themePath, manifest);
 				break;
 			case "html":
-				await applyHtmlTheme(themePath, manifest, themeName);
-				break;
 			case "full":
-				await applyFullTheme(themePath, manifest, themeName);
+				await applyHtmlTheme(themePath, manifest, themeName);
 				break;
 			default:
 				toastr.error(`Unknown theme type "${themeType}" in manifest.`);
@@ -242,24 +240,6 @@ async function applyHtmlTheme(themePath, manifest, themeName) {
 		} catch (error) {
 			console.error(`Failed to load JS file '${jsFile}':`, error);
 		}
-	}
-}
-
-/** Applies a full theme (CSS, HTML, JS) based on the provided manifest.
- * @param {string} themePath - The base path of the theme.
- * @param {Object} manifest - The theme's manifest object.
- * @param {string} themeName - The name of the theme being applied.
- */
-async function applyFullTheme(themePath, manifest, themeName) {
-	try {
-		// Apply CSS
-		await applyCssTheme(themePath, manifest);
-
-		// Apply HTML and JS
-		await applyHtmlTheme(themePath, manifest, themeName);
-	} catch (error) {
-		console.error(`Error applying full theme "${themeName}":`, error);
-		throw error; // Re-throw to be caught in applyTheme
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ async function resetTheme(silent = false) {
 		);
 	}
 	loadedThemeElements.js = null;
-	extension_settings[extensionName].lastSuccessfulTheme = null;
+	extension_settings[extensionName].lastSuccessfulTheme = ""; 
 	saveSettingsDebounced();
 	if (!silent) {
 		toastr.success("Reset back to default SillyTavern theme.");

--- a/index.js
+++ b/index.js
@@ -233,7 +233,8 @@ async function applyHtmlTheme(themePath, manifest, themeName) {
 	if (manifest.files?.js) {
 		const jsFile = `./themes/${themeName}/${manifest.files.js}`;
 		try {
-			const module = await import(`${jsFile}?t=${Date.now()}`); // Cache-busting
+			const manifest = await fetch(`${themePath}/manifest.json`).then(res => res.json());
+			const module = await import(`${jsFile}?t=${manifest.version || "1"}`); // Cache-busting
 			loadedThemeElements.js = module;
 			if (typeof module.execute === "function") {
 				await module.execute();

--- a/index.js
+++ b/index.js
@@ -6,6 +6,12 @@ import {
 } from "./constants.js";
 import { saveSettingsDebounced } from "../../../../script.js";
 
+const loadedThemeElements = {
+	css: [],
+	htmlElements: [],
+	js: null,
+};
+
 async function loadSettings() {
 	extension_settings[extensionName] = extension_settings[extensionName] || {};
 	if (Object.keys(extension_settings[extensionName]).length === 0) {
@@ -18,8 +24,10 @@ async function loadSettings() {
 	);
 	$("#guinevere-theme-input").val(extension_settings[extensionName].theme);
 
-	extension_settings[extensionName].lastSuccessfulTheme = "";
-	saveSettingsDebounced();
+	// If enabled on startup, apply the theme
+	if (extension_settings[extensionName].enabled) {
+		applyTheme(true);
+	}
 }
 
 // Handles the enabling/disabling of Guinevere.
@@ -34,7 +42,6 @@ function onThemeBoxClick(event) {
 
 // Handles the input box for theme selection.
 function onThemeTextChange() {
-	// Get the value of the input box
 	const value = $("#guinevere-theme-input").val();
 	extension_settings[extensionName].theme = value;
 	saveSettingsDebounced();
@@ -42,143 +49,228 @@ function onThemeTextChange() {
 }
 
 // Handles the application of Guinevere themes.
-function onThemeApplyClick() {
+async function onThemeApplyClick() {
 	if (!extension_settings[extensionName].enabled) {
 		toastr.error("Guinevere is not enabled.");
 		return;
 	}
-	applyTheme();
+	await applyTheme();
 }
 
 // Handles the removal of Guinevere themes.
 function onThemeRemoveClick() {
 	resetTheme();
 	extension_settings[extensionName].enabled = false;
-	extension_settings[extensionName].theme = "";
-	saveSettingsDebounced();
 	$("#guinevere-enable").prop("checked", false);
-	$("#guinevere-theme-input").val("");
+	saveSettingsDebounced();
 }
 
 /**
- * Executes the theme's code.js file.
- * @param {any} themeDiv - The div to apply the theme to.
- * @param {boolean} auto - Whether the theme is being applied automatically (on toggle/startup).
+ * Removes all active theme elements from the DOM.
  * @param {boolean} silent - Whether to suppress the success message.
  */
-function executeCode(themeDiv, auto, silent) {
-	if (extension_settings[extensionName].theme === "") {
-		toastr.error("No theme selected.");
-		return;
+async function resetTheme(silent = false) {
+	// Unload CSS
+	for (const linkElement of loadedThemeElements.css) {
+		linkElement.remove();
 	}
+	loadedThemeElements.css = [];
 
-	const themeCode = `./themes/${extension_settings[extensionName].theme}/code.js`;
-	try {
-		import(themeCode)
-			.then((module) => {
-				module.execute(themeDiv, auto);
-				extension_settings[extensionName].lastSuccessfulTheme =
-					extension_settings[extensionName].theme;
-				saveSettingsDebounced();
+	// Unload HTML
+	for (const htmlElement of loadedThemeElements.htmlElements) {
+		htmlElement.remove();
+	}
+	loadedThemeElements.htmlElements = [];
 
-				if (!silent)
-					toastr.success(
-						`Applied '${extension_settings[extensionName].theme}' theme successfully.`,
-					);
-			})
-			.catch((error) => {
-				toastr.error(
-					`Failed to apply '${extension_settings[extensionName].theme}' theme${auto ? " automatically." : "."} Check console for more info.`,
-				);
-				console.error(error);
-			});
-	} catch (error) {
-		toastr.error(
-			`Failed to execute '${extension_settings[extensionName].theme}' code file${auto ? " automatically." : "."} Check console for more info.`,
+	// Unload JS
+	if (
+		loadedThemeElements.js &&
+		typeof loadedThemeElements.js.disable === "function"
+	) {
+		try {
+			await loadedThemeElements.js.disable();
+		} catch (error) {
+			console.error("Error while disabling theme JS:", error);
+			toastr.error(
+				"There was an error while disabling the theme's JavaScript code. Refresh SillyTavern to ensure all theme code is removed and contact the theme developer to fix this error.",
+			);
+		}
+	} else {
+		console.log(
+			`[${extensionName}] No JS to unload for theme "${extension_settings[extensionName].lastSuccessfulTheme}".`,
 		);
-		console.error(error);
 	}
-}
-
-/**
- * Executes the theme's disable code.
- */
-function executeDisableCode() {
-	if (!extension_settings[extensionName].theme === "") {
-		toastr.error("No theme selected.");
-		return;
-	}
-	if (extension_settings[extensionName].lastSuccessfulTheme === "") {
-		toastr.error("No theme has been successfully applied to revert from.");
-		return;
-	}
-
-	// import "disable" from theme's code.js file
-	const themeCode = `./themes/${extension_settings[extensionName].lastSuccessfulTheme}/code.js`;
-	try {
-		import(themeCode)
-			.then((module) => {
-				module.disable();
-			})
-			.catch((error) => {
-				toastr.error(
-					"Failed to revert to default theme. Check console for more info.",
-				);
-				console.error(error);
-			});
-	} catch (error) {
-		toastr.error(
-			"Failed to execute last successful theme's disable code. Check console for more info.",
-		);
-		console.error(error);
+	loadedThemeElements.js = null;
+	extension_settings[extensionName].lastSuccessfulTheme = null;
+	saveSettingsDebounced();
+	if (!silent) {
+		toastr.success("Reset back to default SillyTavern theme.");
 	}
 }
 
 /**
  * Applies a Guinevere theme to the page.
- * @param {boolean} auto - Whether the theme is being applied automatically (on toggle/startup).
  * @param {boolean} silent - Whether to suppress the success message.
  */
-async function applyTheme(auto, silent) {
+async function applyTheme(silent) {
 	// Ensure the last theme is cleaned up before applying a new one
-	resetTheme(true);
+	await resetTheme(true);
 
-	const themeDiv = $("<div id='guinevere-theme'></div>");
-	if (extension_settings[extensionName].enabled) {
-		executeCode(themeDiv, auto, silent);
+	const themeName = extension_settings[extensionName].theme;
+	if (!themeName) {
+		toastr.error("No theme specified.");
+		return;
+	}
+
+	const themePath = `${extensionFolderPath}/themes/${themeName}`;
+	const manifestPath = `${themePath}/manifest.json`;
+
+	try {
+		const manifest = await $.getJSON(manifestPath);
+		const themeType = manifest.type || "full";
+
+		switch (themeType) {
+			case "css":
+				await applyCssTheme(themePath, manifest);
+				break;
+			case "html":
+				await applyHtmlTheme(themePath, manifest, themeName);
+				break;
+			case "full":
+				await applyFullTheme(themePath, manifest, themeName);
+				break;
+			default:
+				toastr.error(`Unknown theme type "${themeType}" in manifest.`);
+				return;
+		}
+
+		extension_settings[extensionName].lastSuccessfulTheme = themeName;
+		if (!silent) {
+			toastr.success(
+				`Applied '${manifest.name || themeName}' theme successfully.`,
+			);
+		}
+	} catch (error) {
+		console.error(`Failed to load/apply theme '${themeName}':`, error);
+		toastr.error(
+			`Failed to load/apply theme "${themeName}". Check the console for details.`,
+		);
 	}
 }
 
 /**
- * Resets the theme back to the default theme.
- * @param {boolean} silent - Whether to suppress the success message.
- * @returns {void}
+ * Applies a CSS file to the document.
+ * @param {string} cssPath - The path to the CSS file.
  */
-function resetTheme(silent) {
-	const themeDiv = $("#guinevere-theme");
-	if (themeDiv.length === 0) {
-		return;
+function applyCssFile(cssPath) {
+	const link = document.createElement("link");
+	link.rel = "stylesheet";
+	link.type = "text/css";
+	link.href = cssPath;
+	document.head.appendChild(link);
+	loadedThemeElements.css.push($(link));
+}
+
+/**
+ * Applies a CSS theme based on the provided manifest.
+ * @param {string} themePath - The base path of the theme.
+ * @param {Object} manifest - The theme's manifest object.
+ */
+async function applyCssTheme(themePath, manifest) {
+	if (manifest.files?.css) {
+		for (const cssFile of manifest.files.css) {
+			applyCssFile(`${themePath}/${cssFile}`);
+		}
 	}
-	executeDisableCode(themeDiv);
-	$("#guinevere-theme-input").val(extension_settings[extensionName].theme);
-	$("#guinevere-enable").prop(
-		"checked",
-		extension_settings[extensionName].enabled,
-	);
-	if (!silent) toastr.success("Reverted to default theme.");
+}
+
+/**
+ * Applies an HTML theme based on the provided manifest.
+ * @param {string} themePath - The base path of the theme.
+ * @param {Object} manifest - The theme's manifest object.
+ * @param {string} themeName - The name of the theme being applied.
+ */
+async function applyHtmlTheme(themePath, manifest, themeName) {
+	// Apply CSS first (if any)
+	await applyCssTheme(themePath, manifest);
+
+	// Apply HTML
+	if (manifest.files?.html) {
+		for (const htmlFile of manifest.files.html) {
+			const htmlContent = await $.get(`${themePath}/${htmlFile}`);
+
+			// Parse the HTML contents
+			const elements = $($.parseHTML(htmlContent.trim()));
+
+			// Inject element before the main ST UI (#top-bar), unless specified otherwise
+			const injectPoint = manifest.injectPoint || "#top-bar";
+			const injectMethod = manifest.injectMethod || "before";
+
+			for (const element of elements) {
+				const el = $(element);
+
+				switch (injectMethod) {
+					case "after":
+						$(injectPoint).after(el);
+						break;
+					case "prepend":
+						$(injectPoint).prepend(el);
+						break;
+					case "append":
+						$(injectPoint).append(el);
+						break;
+					default:
+						$(injectPoint).before(el);
+						break;
+				}
+				// Store reference for later removal
+				loadedThemeElements.htmlElements.push(el);
+			}
+		}
+	}
+
+	// Apply JS (if any)
+	if (manifest.files?.js) {
+		const jsFile = `./themes/${themeName}/${manifest.files.js}`;
+		try {
+			const module = await import(`${jsFile}?t=${Date.now()}`); // Cache-busting
+			loadedThemeElements.js = module;
+			if (typeof module.execute === "function") {
+				await module.execute();
+			}
+		} catch (error) {
+			console.error(`Failed to load JS file '${jsFile}':`, error);
+		}
+	}
+}
+
+/** Applies a full theme (CSS, HTML, JS) based on the provided manifest.
+ * @param {string} themePath - The base path of the theme.
+ * @param {Object} manifest - The theme's manifest object.
+ * @param {string} themeName - The name of the theme being applied.
+ */
+async function applyFullTheme(themePath, manifest, themeName) {
+	try {
+		// Apply CSS
+		await applyCssTheme(themePath, manifest);
+
+		// Apply HTML and JS
+		await applyHtmlTheme(themePath, manifest, themeName);
+	} catch (error) {
+		console.error(`Error applying full theme "${themeName}":`, error);
+		throw error; // Re-throw to be caught in applyTheme
+	}
 }
 
 // This function is called when the extension is loaded
-jQuery(async () => {
+$(document).ready(async () => {
 	const settingsHtml = await $.get(`${extensionFolderPath}/settings.html`);
 	$("#extensions_settings").append(settingsHtml);
 
-	loadSettings();
+	await loadSettings();
 
 	$("#guinevere-enable").on("click", onThemeBoxClick);
 	$("#guinevere-apply").on("click", onThemeApplyClick);
 	$("#guinevere-reset").on("click", onThemeRemoveClick);
 	$("#guinevere-theme-text-button").on("click", onThemeTextChange);
-
-	await applyTheme(true, true);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
 	"js": "index.js",
 	"css": "style.css",
 	"author": "Bronya Rand",
-	"version": "1.0.1",
+	"version": "2.0.0-beta1",
 	"homePage": "https://github.com/Bronya-Rand/Guinevere-UI-Extension"
 }

--- a/settings.html
+++ b/settings.html
@@ -73,7 +73,7 @@
                         <span>Guinevere UI Extension Version
                             <a id="guinevere-version-number"
                                 href="https://github.com/Bronya-Rand/Guinevere-UI-Extension" target="_blank"
-                                rel="noopener noreferrer">1.0.0</a></span>
+                                rel="noopener noreferrer">2.0.0 (Beta 1)</a></span>
                     </small>
                 </div>
             </div>

--- a/themes/google-messages/code.js
+++ b/themes/google-messages/code.js
@@ -12,6 +12,7 @@ import { debounce_timeout } from "../../../../../constants.js";
  * @property {string} key - The id of the old div (top-settings-holder).
  * @property {string} value - The id of the new div (google-st-preview).
  */
+const HTML_CONTAINER = $("#google-messages-container");
 const ATTACH_TO_FROM = {};
 const profileDataDebounce = debounce(setProfile, debounce_timeout.quick);
 
@@ -34,14 +35,13 @@ function setProfile() {
 
 /**
  * Executes the Google Messages theme code.
- * @param {any} themeDiv - The div to apply the theme to
- * @param {boolean} auto - Whether the theme is being applied automatically (on toggle/startup)
  */
-export async function execute(themeDiv, auto) {
+export async function execute() {
 	const topSettingsHolder = $("#top-settings-holder");
 	if (!topSettingsHolder.length) {
 		throw Error("Failed to find top-settings-holder.");
 	}
+	const themeDiv = HTML_CONTAINER;
 
 	// Apply theme via new div
 	const themeHTMLPath = `${extensionFolderPath}/themes/google-messages/index.html`;
@@ -144,17 +144,6 @@ export async function execute(themeDiv, auto) {
 		throw Error(error);
 	}
 
-	const cssPath = `${extensionFolderPath}/themes/google-messages/style.css`;
-	try {
-		const cssData = await $.get(cssPath);
-		$("#guinevere-theme-css").remove();
-		$("<style id='guinevere-theme-css'></style>")
-			.html(cssData)
-			.appendTo("head");
-	} catch (error) {
-		throw Error(error);
-	}
-
 	eventSource.on(event_types.SETTINGS_UPDATED, profileDataDebounce);
 
 	topSettingsHolder.css("display", "none");
@@ -165,14 +154,17 @@ export function disable() {
 	const topSettingsHolder = $("#top-settings-holder");
 
 	// Detach all elements from the new div to the old div
-	const stPreviewer = $("#guinevere-theme").find("#google-st-preview");
+	const stPreviewer = HTML_CONTAINER.find("#google-st-preview");
 
 	for (const [key, value] of Object.entries(ATTACH_TO_FROM)) {
 		const oldDrawerContent = topSettingsHolder.find(`#${key}`);
 		const newDrawerContent = stPreviewer.find(`#${value}`);
 
 		newDrawerContent.removeClass("google-message-st-option-preview");
-		newDrawerContent.css("display", "none");
+
+		// Clear all styles
+		newDrawerContent.attr("style", "");
+
 		newDrawerContent.detach();
 		oldDrawerContent.append(newDrawerContent);
 	}
@@ -207,8 +199,4 @@ export function disable() {
 	// remove display element from top-settings-holder
 	topSettingsHolder.css("display", "flex");
 	$("#top-bar").css("display", "flex");
-
-	// remove css
-	$("#guinevere-theme-css").remove();
-	$("#guinevere-theme").empty();
 }

--- a/themes/google-messages/code.js
+++ b/themes/google-messages/code.js
@@ -40,32 +40,31 @@ export async function execute() {
 	if (!topSettingsHolder.length) {
 		throw Error("Failed to find top-settings-holder.");
 	}
-	const themeDiv = HTML_CONTAINER;
 
 	try {
 		// Add logic to google-message-settings-icon (Profile icon)
-		themeDiv.find("#google-message-settings-icon").on("click", () => {
+		HTML_CONTAINER.find("#google-message-settings-icon").on("click", () => {
 			$("#google-message-settings-modal").toggle();
 		});
 
 		// Add logic to google-message-modal-settings-button (ST Settings button)
-		themeDiv.find("#google-message-modal-settings-button").on("click", () => {
+		HTML_CONTAINER.find("#google-message-modal-settings-button").on("click", () => {
 			$("#google-message-settings-modal").hide();
 			$("#google-message-st-settings-modal").toggle();
 		});
 
 		// Add logic to google-message-st-modal-close (close button)
-		themeDiv.find("#google-message-st-modal-close").on("click", () => {
+		HTML_CONTAINER.find("#google-message-st-modal-close").on("click", () => {
 			$("#google-message-st-settings-modal").hide();
 		});
 
 		setProfile();
 
-		// Append themeDiv above top-bar
-		topSettingsHolder.before(themeDiv);
+		// Append HTML_CONTAINER above top-bar
+		topSettingsHolder.before(HTML_CONTAINER);
 
-		const stOptions = themeDiv.find("#google-st-options");
-		const stPreviewer = themeDiv.find("#google-st-preview");
+		const stOptions = HTML_CONTAINER.find("#google-st-options");
+		const stPreviewer = HTML_CONTAINER.find("#google-st-preview");
 
 		// Grab data from top-settings-holder
 		const drawerButtons = topSettingsHolder.find(".drawer");

--- a/themes/google-messages/code.js
+++ b/themes/google-messages/code.js
@@ -1,4 +1,3 @@
-import { extensionFolderPath } from "../../constants.js";
 import { select2ChoiceClickSubscribe } from "../../../../../utils.js";
 import { world_names } from "../../../../../world-info.js";
 import { eventSource, event_types, name1 } from "../../../../../../script.js";
@@ -43,13 +42,7 @@ export async function execute() {
 	}
 	const themeDiv = HTML_CONTAINER;
 
-	// Apply theme via new div
-	const themeHTMLPath = `${extensionFolderPath}/themes/google-messages/index.html`;
-
 	try {
-		const data = await $.get(themeHTMLPath);
-		themeDiv.html(data);
-
 		// Add logic to google-message-settings-icon (Profile icon)
 		themeDiv.find("#google-message-settings-icon").on("click", () => {
 			$("#google-message-settings-modal").toggle();

--- a/themes/google-messages/index.html
+++ b/themes/google-messages/index.html
@@ -1,47 +1,49 @@
 <!-- Google Messages Profile UI -->
 
-<button id="google-message-settings-icon">
-    <img id="google-message-settings-profile-icon" class="google-message-settings-profile-image" title="SillyTavern Account" data-i18n="SillyTavern Account" alt="Profile Image"></img>
-</button>
+<div id="google-messages-container">
+    <button id="google-message-settings-icon">
+        <img id="google-message-settings-profile-icon" class="google-message-settings-profile-image" title="SillyTavern Account" data-i18n="SillyTavern Account" alt="Profile Image"></img>
+    </button>
 
-<div id="google-message-settings-modal" class="google-message-modal">
-    <div id="google-message-setting-modal" class="google-message-modal-content">
-        <div class="google-message-modal-settings">
-            <p class="google-message-modal-google-text">SillyTavern</p>
-            <img id="google-message-modal-profile-icon" class="google-message-modal-profile-image" alt="Profile Image"></img>
-            <div class="flex-container flexFlowColumn">
-                <p id="google-message-modal-profile-name" class="google-message-modal-profile-name">Hi, SillyTavern User!</p>
-                <button id="google-message-modal-settings-button" class="google-message-modal-settings-button"
-                    data-i18n="SillyTavern Settings">
-                    SillyTavern Settings
-                </button>
+    <div id="google-message-settings-modal" class="google-message-modal">
+        <div id="google-message-setting-modal" class="google-message-modal-content">
+            <div class="google-message-modal-settings">
+                <p class="google-message-modal-google-text">SillyTavern</p>
+                <img id="google-message-modal-profile-icon" class="google-message-modal-profile-image" alt="Profile Image"></img>
+                <div class="flex-container flexFlowColumn">
+                    <p id="google-message-modal-profile-name" class="google-message-modal-profile-name">Hi, SillyTavern User!</p>
+                    <button id="google-message-modal-settings-button" class="google-message-modal-settings-button"
+                        data-i18n="SillyTavern Settings">
+                        SillyTavern Settings
+                    </button>
+                    </div>
+
+                <div class="google-message-modal-terms-div">
+                    <span>
+                        <a rel="noopener" href="https://docs.sillytavern.app" class="google-message-modal-terms"
+                            data-i18n="Documentation">Documentation</a>
+                        &middot;
+                        <a rel="noopener" href="https://discord.gg/sillytavern"
+                            class="google-message-modal-terms">Discord</a>
+                        &middot;
+                        <small class="google-message-modal-terms">Theme by: Bronya Rand</small>
+                    </span>
                 </div>
-
-            <div class="google-message-modal-terms-div">
-                <span>
-                    <a rel="noopener" href="https://docs.sillytavern.app" class="google-message-modal-terms"
-                        data-i18n="Documentation">Documentation</a>
-                    &middot;
-                    <a rel="noopener" href="https://discord.gg/sillytavern"
-                        class="google-message-modal-terms">Discord</a>
-                    &middot;
-                    <small class="google-message-modal-terms">Theme by: Bronya Rand</small>
-                </span>
             </div>
         </div>
     </div>
-</div>
 
-<div id="google-message-st-settings-modal" class="google-message-general-modal">
-    <div id="google-message-st-setting-modal" class="google-message-general-modal-content">
-        <div class="google-message-st-modal-settings">
-            <div class="google-message-st-modal-title-div">
-                <h2 class="google-message-st-modal-title" data-i18n="SillyTavern Settings">SillyTavern Settings</h2>
-                <button id="google-message-st-modal-close" class="google-message-st-modal-close">&times;</button>
-            </div>
-            <div class="google-message-st-modal-settings2">
-                <div id="google-st-options" class="google-message-st-options"></div>
-                <div id="google-st-preview" class="google-message-st-options-preview"></div>
+    <div id="google-message-st-settings-modal" class="google-message-general-modal">
+        <div id="google-message-st-setting-modal" class="google-message-general-modal-content">
+            <div class="google-message-st-modal-settings">
+                <div class="google-message-st-modal-title-div">
+                    <h2 class="google-message-st-modal-title" data-i18n="SillyTavern Settings">SillyTavern Settings</h2>
+                    <button id="google-message-st-modal-close" class="google-message-st-modal-close">&times;</button>
+                </div>
+                <div class="google-message-st-modal-settings2">
+                    <div id="google-st-options" class="google-message-st-options"></div>
+                    <div id="google-st-preview" class="google-message-st-options-preview"></div>
+                </div>
             </div>
         </div>
     </div>

--- a/themes/google-messages/index.html
+++ b/themes/google-messages/index.html
@@ -1,6 +1,5 @@
-<!-- Google Messages Profile UI -->
-
 <div id="google-messages-container">
+    <!-- Google Messages Profile UI -->
     <button id="google-message-settings-icon">
         <img id="google-message-settings-profile-icon" class="google-message-settings-profile-image" title="SillyTavern Account" data-i18n="SillyTavern Account" alt="Profile Image"></img>
     </button>

--- a/themes/google-messages/manifest.json
+++ b/themes/google-messages/manifest.json
@@ -1,0 +1,15 @@
+{
+    "name": "Google Messages",
+    "version": "1.0.0",
+    "author": "Bronya-Rand",
+    "type": "full",
+    "files": {
+        "css": [
+            "style.css"
+        ],
+        "html": [
+            "index.html"
+        ],
+        "js": "code.js"
+    }
+}

--- a/themes/template/README.md
+++ b/themes/template/README.md
@@ -1,0 +1,12 @@
+# About `manifest.json`
+Starting from Guinevere 2.0, all themes will be required to record all their files and the type of theme under a JSON file.
+
+Important fields to keep in mind are:
+- Name: Basically the human friendly name of your theme.
+- Type: This specifies the type of theme you are using. This can be either:
+
+    1. "css" - A pure CSS theme.
+    2. "html" - A HTML theme only OR a HTML/CSS theme OR HTML/JS
+    3. "full" - A whole theme with JS/HTML/CSS. Can also be used for pure JS add-ins.
+
+- Files: This keeps a record of what Guinevere should load to its memory cache for unloading your theme. This is important for cleanup reasons. This doesn't take away your responsibility to make sure your theme cleans up after itself for other themes or to base ST.

--- a/themes/template/README.md
+++ b/themes/template/README.md
@@ -3,6 +3,7 @@ Starting from Guinevere 2.0, all themes will be required to record all their fil
 
 Important fields to keep in mind are:
 - Name: Basically the human friendly name of your theme.
+- Version: Version of your theme.
 - Type: This specifies the type of theme you are using. This can be either:
 
     1. "css" - A pure CSS theme.

--- a/themes/template/code.js
+++ b/themes/template/code.js
@@ -12,52 +12,21 @@
  * example to get you started.
  */
 
-import { extensionFolderPath } from "../../constants.js";
+const HTML_CONTAINER = $("#template-container");
 
 /**
  * Executes the Template theme code.
- * @param {any} themeDiv - The div to apply the theme to
- * @param {*} auto - Whether the theme is being applied automatically (on toggle/startup)
+ * @note Breaking Change as of Guinevere 2.0: `auto` and `themeDiv` parameters are now removed.
+ * It is now recommended to make a container of your HTML contents in your theme's HTML file.
  */
-export async function execute(themeDiv, auto) {
-	// Don't touch this.
-	const topSettingsHolder = $("#top-settings-holder");
-	if (!topSettingsHolder.length) {
-		throw Error("Failed to find top-settings-holder.");
-	}
-
-	// Path to the theme's index.html file
-	const themeHTMLPath = `${extensionFolderPath}/themes/template/index.html`;
-
+export async function execute() {
 	try {
-		const data = await $.get(themeHTMLPath);
-		themeDiv.html(data);
-
 		// Your code here (e.g. event listeners, logic, etc.)
-		// Preferralby assign jQuery logic to the new stuff you added to your theme.
-
-		// Appends your theme above the top bar
-		// If you want this after, use `after` instead of `before`.
-		topSettingsHolder.before(themeDiv);
-
-		// Additional code here (e.g. event listeners, logic, etc.)
-		// This is for if you want to add more logic to your theme that only works
-		// after the theme has been appended to the page.
+		// Preferably assign jQuery logic to the new stuff you added to your theme.
+		console.log("Template theme code executed.");
 	} catch (error) {
 		throw Error(error);
 	}
-
-	// Uncomment these lines if you want to use your own CSS file
-	// for the theme.
-	// Path to the theme's CSS file
-	// const cssPath = `${extensionFolderPath}/themes/template/style.css`;
-	// try {
-	// 	const cssData = await $.get(cssPath);
-	// 	$("#guinevere-theme-css").remove();
-	// 	$("<style id='guinevere-theme-css'></style>").html(cssData).appendTo("head");
-	// } catch (error) {
-	// 	throw Error(error);
-	// };
 }
 
 /**
@@ -65,7 +34,4 @@ export async function execute(themeDiv, auto) {
  */
 export function disable() {
 	// Your removal code here (if applicable)
-	// Removes the theme's CSS. If you used your own CSS file, uncomment this.
-	// $("#guinevere-theme-css").remove();
-	$("#guinevere-theme").empty();
 }

--- a/themes/template/index.html
+++ b/themes/template/index.html
@@ -3,6 +3,8 @@
     however this theme is rather complicated in of itself. 
     Remember. Start small, save, and keep building upon it. -->
     
-<div class="theme-example">
-    <p>Place HTML code here</p>
+<div id="template-container">
+    <div class="theme-example">
+        <p>Place HTML code here</p>
+    </div>
 </div>

--- a/themes/template/manifest.json
+++ b/themes/template/manifest.json
@@ -1,0 +1,15 @@
+{
+    "name": "Sample Theme Template",
+    "version": "1.0.0",
+    "author": "YourName",
+    "type": "full",
+    "files": {
+        "css": [
+            "style.css"
+        ],
+        "html": [
+            "index.html"
+        ],
+        "js": "code.js"
+    }
+}


### PR DESCRIPTION
This refactor does the following:
- Rewrites all of Guinevere's logic code for CSS only, HTML only, JS only, HTML/CSS, HTML/JS and CSS/HTML/JS themes.
- Add manifest JSON dependency.
- Removes need for themeDiv and `<div id="guinevere-theme">`
- Add records of loaded CSS,HTML,JS contents per theme.
- Removes dependency of themeDiv and auto from execute
- Deprecated `executeCode` for auto-JS application for HTML.
- Deprecated `executeDisableCode` for auto-JS removal in `resetTheme`.

## Fixes
- Fixed a bug where Google Messages keeps "hold" of ST's dropdowns (style issue)